### PR TITLE
Useful commands that were missing

### DIFF
--- a/src/main/java/de/melanx/skyblockbuilder/EventListener.java
+++ b/src/main/java/de/melanx/skyblockbuilder/EventListener.java
@@ -62,6 +62,7 @@ public class EventListener {
                 .then(TeamCommand.register())
                 .then(LeaveCommand.register())
                 .then(HomeCommand.register())
+                .then(CreateCommand.register())
                 .then(SpawnsCommand.register()));
     }
 

--- a/src/main/java/de/melanx/skyblockbuilder/EventListener.java
+++ b/src/main/java/de/melanx/skyblockbuilder/EventListener.java
@@ -61,6 +61,7 @@ public class EventListener {
                 .then(ListCommand.register())
                 .then(TeamCommand.register())
                 .then(LeaveCommand.register())
+                .then(HomeCommand.register())
                 .then(SpawnsCommand.register()));
     }
 

--- a/src/main/java/de/melanx/skyblockbuilder/EventListener.java
+++ b/src/main/java/de/melanx/skyblockbuilder/EventListener.java
@@ -57,12 +57,12 @@ public class EventListener {
         event.getDispatcher().register(Commands.literal("skyblock")
                 .requires(source -> WorldUtil.isSkyblock(source.getWorld()))
                 .then(AcceptCommand.register())
+                .then(CreateCommand.register())
+                .then(HomeCommand.register())
                 .then(InviteCommand.register())
+                .then(LeaveCommand.register())
                 .then(ListCommand.register())
                 .then(TeamCommand.register())
-                .then(LeaveCommand.register())
-                .then(HomeCommand.register())
-                .then(CreateCommand.register())
                 .then(SpawnsCommand.register()));
     }
 

--- a/src/main/java/de/melanx/skyblockbuilder/EventListener.java
+++ b/src/main/java/de/melanx/skyblockbuilder/EventListener.java
@@ -60,6 +60,7 @@ public class EventListener {
                 .then(InviteCommand.register())
                 .then(ListCommand.register())
                 .then(TeamCommand.register())
+                .then(LeaveCommand.register())
                 .then(SpawnsCommand.register()));
     }
 

--- a/src/main/java/de/melanx/skyblockbuilder/commands/CreateCommand.java
+++ b/src/main/java/de/melanx/skyblockbuilder/commands/CreateCommand.java
@@ -1,0 +1,59 @@
+package de.melanx.skyblockbuilder.commands;
+
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import de.melanx.skyblockbuilder.util.NameGenerator;
+import de.melanx.skyblockbuilder.util.Team;
+import de.melanx.skyblockbuilder.util.WorldUtil;
+import de.melanx.skyblockbuilder.world.data.SkyblockSavedData;
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.Commands;
+import net.minecraft.command.arguments.EntityArgument;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.world.server.ServerWorld;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Random;
+
+public class CreateCommand {
+
+    public static ArgumentBuilder<CommandSource, ?> register() {
+        return Commands.literal("create")
+                .executes(context -> create(context.getSource(), NameGenerator.randomName(new Random()), Arrays.asList(context.getSource().asPlayer())))
+                .then(Commands.argument("name", StringArgumentType.word())
+                        .executes(context -> create(context.getSource(), StringArgumentType.getString(context, "name"), Arrays.asList(context.getSource().asPlayer())))
+                        .then(Commands.argument("players", EntityArgument.players())
+                                .requires(commandSource -> commandSource.hasPermissionLevel(2))
+                                .executes(context -> create(context.getSource(), StringArgumentType.getString(context, "name"), EntityArgument.getPlayers(context, "players")))));
+    }
+
+
+    private static int create(CommandSource source, String name, Collection<ServerPlayerEntity> players) throws CommandSyntaxException {
+        ServerWorld world = source.getWorld();
+        SkyblockSavedData data = SkyblockSavedData.get(world);
+
+        if (data.teamExists(name)) {
+            source.sendFeedback(new StringTextComponent(String.format("Team %s already exists! Please choose another name!", name)).mergeStyle(TextFormatting.RED), true);
+            return 0;
+        }
+
+        Team team = data.createTeam(name);
+
+        players.forEach(serverPlayerEntity -> {
+            if (data.getTeamFromPlayer(serverPlayerEntity) != null) {
+                source.sendFeedback(new StringTextComponent(String.format("%s is already in a team, it can not be added!", serverPlayerEntity.getDisplayName().getString())).mergeStyle(TextFormatting.RED), false);
+            } else {
+                team.addPlayer(serverPlayerEntity);
+                WorldUtil.teleportToIsland(serverPlayerEntity, team.getIsland());
+            }
+        });
+
+
+        source.sendFeedback(new StringTextComponent(String.format(("Successfully created team %s."), name)).mergeStyle(TextFormatting.GREEN), true);
+        return 1;
+    }
+}

--- a/src/main/java/de/melanx/skyblockbuilder/commands/HomeCommand.java
+++ b/src/main/java/de/melanx/skyblockbuilder/commands/HomeCommand.java
@@ -2,6 +2,7 @@ package de.melanx.skyblockbuilder.commands;
 
 import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import de.melanx.skyblockbuilder.util.Team;
 import de.melanx.skyblockbuilder.util.WorldUtil;
 import de.melanx.skyblockbuilder.world.data.SkyblockSavedData;
 import net.minecraft.command.CommandSource;

--- a/src/main/java/de/melanx/skyblockbuilder/commands/HomeCommand.java
+++ b/src/main/java/de/melanx/skyblockbuilder/commands/HomeCommand.java
@@ -25,11 +25,13 @@ public class HomeCommand {
         ServerWorld world = source.getWorld();
         SkyblockSavedData data = SkyblockSavedData.get(world);
         ServerPlayerEntity player = source.asPlayer();
-        if (data.getTeamFromPlayer(player) != null) {
-            WorldUtil.teleportToIsland(player, data.getTeamFromPlayer(player).getIsland());
-        } else {
+        Team team = data.getTeamFromPlayer(player);
+        if (team == null) {
             source.sendFeedback(new StringTextComponent("You currently in no team!").mergeStyle(TextFormatting.RED), false);
+            return 0;
         }
+
+        WorldUtil.teleportToIsland(player, data.getTeamFromPlayer(player).getIsland());
         return 1;
     }
 }

--- a/src/main/java/de/melanx/skyblockbuilder/commands/HomeCommand.java
+++ b/src/main/java/de/melanx/skyblockbuilder/commands/HomeCommand.java
@@ -1,0 +1,35 @@
+package de.melanx.skyblockbuilder.commands;
+
+import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import de.melanx.skyblockbuilder.util.WorldUtil;
+import de.melanx.skyblockbuilder.world.data.SkyblockSavedData;
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.Commands;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.world.server.ServerWorld;
+
+public class HomeCommand {
+
+    public static ArgumentBuilder<CommandSource, ?> register() {
+        return Commands.literal("home")
+                .executes(context -> home(context.getSource()));
+    }
+
+    private static int home(CommandSource source) throws CommandSyntaxException {
+        if (!(source.getEntity() instanceof ServerPlayerEntity)) {
+            return 0;
+        }
+        ServerWorld world = source.getWorld();
+        SkyblockSavedData data = SkyblockSavedData.get(world);
+        ServerPlayerEntity player = source.asPlayer();
+        if (data.getTeamFromPlayer(player) != null) {
+            WorldUtil.teleportToIsland(player, data.getTeamFromPlayer(player).getIsland());
+        } else {
+            source.sendFeedback(new StringTextComponent("You currently in no team!").mergeStyle(TextFormatting.RED), false);
+        }
+        return 1;
+    }
+}

--- a/src/main/java/de/melanx/skyblockbuilder/commands/LeaveCommand.java
+++ b/src/main/java/de/melanx/skyblockbuilder/commands/LeaveCommand.java
@@ -2,6 +2,7 @@ package de.melanx.skyblockbuilder.commands;
 
 import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import de.melanx.skyblockbuilder.util.WorldUtil;
 import de.melanx.skyblockbuilder.world.data.SkyblockSavedData;
 import net.minecraft.command.CommandSource;
 import net.minecraft.command.Commands;
@@ -29,6 +30,7 @@ public class LeaveCommand {
         player.inventory.dropAllItems();
         data.removePlayerFromTeam(player);
         source.sendFeedback(new StringTextComponent("Successfully left your teammates alone.").mergeStyle(TextFormatting.GOLD), false);
+        WorldUtil.teleportToIsland(player, data.getSpawn());
         return 1;
     }
 }

--- a/src/main/java/de/melanx/skyblockbuilder/commands/TeamCommand.java
+++ b/src/main/java/de/melanx/skyblockbuilder/commands/TeamCommand.java
@@ -108,6 +108,7 @@ public class TeamCommand {
             source.sendFeedback(new StringTextComponent(String.format("Team %s already exists! Please choose another name!", name)).mergeStyle(TextFormatting.RED), true);
             return 0;
         }
+        Team team = data.createTeam(name);
 
 
         if (join) {
@@ -117,7 +118,6 @@ public class TeamCommand {
                     source.sendFeedback(new StringTextComponent("You are already in a team, to create a new one you have to leave your team first!"), false);
                     return 1;
                 }
-                Team team = data.createTeam(name);
 
                 //noinspection ConstantConditions
                 team.addPlayer(player);
@@ -126,8 +126,6 @@ public class TeamCommand {
                 source.sendFeedback(new StringTextComponent("You are no player, how do you want to join?"), false);
                 return 1;
             }
-        } else {
-            Team team = data.createTeam(name);
         }
 
         source.sendFeedback(new StringTextComponent(String.format(("Successfully created team %s."), name)).mergeStyle(TextFormatting.GREEN), true);

--- a/src/main/java/de/melanx/skyblockbuilder/commands/TeamCommand.java
+++ b/src/main/java/de/melanx/skyblockbuilder/commands/TeamCommand.java
@@ -115,8 +115,8 @@ public class TeamCommand {
             try {
                 ServerPlayerEntity player = source.asPlayer();
                 if (data.getTeamFromPlayer(player) != null) {
-                    source.sendFeedback(new StringTextComponent("You are already in a team, to create a new one you have to leave your team first!"), false);
-                    return 1;
+                    source.sendFeedback(new StringTextComponent("You are already in a team, to create a new one you have to leave your team first!").mergeStyle(TextFormatting.RED), false);
+                    return 0;
                 }
 
                 //noinspection ConstantConditions

--- a/src/main/java/de/melanx/skyblockbuilder/commands/TeamCommand.java
+++ b/src/main/java/de/melanx/skyblockbuilder/commands/TeamCommand.java
@@ -109,11 +109,16 @@ public class TeamCommand {
             return 0;
         }
 
-        Team team = data.createTeam(name);
 
         if (join) {
             try {
                 ServerPlayerEntity player = source.asPlayer();
+                if (data.getTeamFromPlayer(player) != null) {
+                    source.sendFeedback(new StringTextComponent("You are already in a team, to create a new one you have to leave your team first!"), false);
+                    return 1;
+                }
+                Team team = data.createTeam(name);
+
                 //noinspection ConstantConditions
                 team.addPlayer(player);
                 WorldUtil.teleportToIsland(player, team.getIsland());
@@ -121,6 +126,8 @@ public class TeamCommand {
                 source.sendFeedback(new StringTextComponent("You are no player, how do you want to join?"), false);
                 return 1;
             }
+        } else {
+            Team team = data.createTeam(name);
         }
 
         source.sendFeedback(new StringTextComponent(String.format(("Successfully created team %s."), name)).mergeStyle(TextFormatting.GREEN), true);


### PR DESCRIPTION
Hi, I like the mod very well! unfortunately I missed a few commands. Instead of creating an issue, I briefly added it myself.
If you have any questions just ask.

I would like to add more commands and config options later on. But first I want to ask what you think of it.

Commands I would like to add:
/skyblock team setspawn (set the island spawn point)
/skyblock visit <team> (can only go if someone from the other team is online, everyone in the team receives a message and can then click on YES or NO in the chat)
/skyblock team info (gives information about the team, players etc.)
/skyblock team chat <message> (sends a message to team members only)
/sc <message> (-> /skyblock team chat)


Config options:
dropInventoryOnLeaveTeam
allowVisits
islandDistance = 8000? 

and maybe an internal Admin role in a team. Team creator -> Team Admin
He can then execute further commands
/skyblock team addAdmin <PlayerInTeam>
/skyblock team removeAdmin <Player>
/skyblock team disableVisit
/skyblock team enableVisit
/skyblock team kick <Player>
/skyblock team invite <Player>
/skyblock team accept <Player>
/skyblock team reject <Player>
/skyblock team setspawn
/skyblock team rename <newname>

Maybe we can also see if we are using a few features with FTB teams, chunks.

There are definitely more things that can be added later.
I am also ready to add these things myself, if you have no time.