### PR TITLE
Add per team dimension generation

### DIFF
--- a/.github/workflows/dev_publish.yml
+++ b/.github/workflows/dev_publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
 
       - name: Build
         run: |

--- a/.github/workflows/dev_publish.yml
+++ b/.github/workflows/dev_publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'update/1.21.x'
+      - 'feature/per-team-dimensions'
 
 jobs:
   publish:
@@ -37,6 +37,6 @@ jobs:
           avatar-url: https://cdn.discordapp.com/avatars/1254781618196054108/724c24e2324939a8c8cfd17fb55f76e8.webp?size=256
           embed-title: "Skyblock Builder"
           embed-url: "https://github.com/ChaoticTrials/SkyblockBuilder/actions/runs/${{ github.run_id }}"
-          embed-description: "A new build has been completed on the `update/1.21.x` branch! [View build details](https://github.com/ChaoticTrials/SkyblockBuilder/actions/runs/${{ github.run_id }})"
+          embed-description: "A new build has been completed on the `${{ github.ref_name }}` branch! [View build details](https://github.com/ChaoticTrials/SkyblockBuilder/actions/runs/${{ github.run_id }})"
           embed-author-name: "Endermite"
           embed-thumbnail-url: "https://avatars.githubusercontent.com/u/172169094"

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ repositories {
         name = "Team Resourceful"
         url = "https://maven.teamresourceful.com/repository/maven-public/"
     }
+    maven { url "https://maven.commoble.net/" }
     exclusiveContent {
         forRepository {
             maven {
@@ -117,5 +118,6 @@ dependencies {
 
     runtimeOnly "mezz.jei:jei-1.${baseVersion}-neoforge:${jeiVersion}"
     runtimeOnly "de.melanx:DefaultWorldType:1.21-5.0.0"
+    implementation "net.commoble.infiniverse:infiniverse-1.21:2.0.1.0"
     compileOnly(jarJar(project(":coremods")))
 }

--- a/src/main/java/de/melanx/skyblockbuilder/EventListener.java
+++ b/src/main/java/de/melanx/skyblockbuilder/EventListener.java
@@ -17,6 +17,7 @@ import de.melanx.skyblockbuilder.commands.teleport.HomeCommand;
 import de.melanx.skyblockbuilder.commands.teleport.SpawnCommand;
 import de.melanx.skyblockbuilder.commands.teleport.VisitCommand;
 import de.melanx.skyblockbuilder.compat.CadmusCompat;
+import de.melanx.skyblockbuilder.compat.infiniverse.InfiniverseCompat;
 import de.melanx.skyblockbuilder.config.common.*;
 import de.melanx.skyblockbuilder.data.SkyblockSavedData;
 import de.melanx.skyblockbuilder.data.Team;
@@ -142,6 +143,11 @@ public class EventListener {
             ServerPlayer player = (ServerPlayer) event.getEntity();
             Team spawn = data.getSpawn();
             GameProfileCache.addProfiles(Set.of(player.getGameProfile()));
+
+            if (WorldConfig.dimensionPerTeam && !ModList.get().isLoaded(InfiniverseCompat.MODID) && player.hasPermissions(Commands.LEVEL_GAMEMASTERS)) {
+                player.sendSystemMessage(Component.translatable("infiniverse.skyblockbuilder.not_loaded").withStyle(ChatFormatting.RED));
+            }
+
             if (player.getPersistentData().getBoolean(SPAWNED_TAG)) {
                 if (!data.hasPlayerTeam(player) && !spawn.hasPlayer(player)) {
                     if (InventoryConfig.dropItems) {

--- a/src/main/java/de/melanx/skyblockbuilder/compat/infiniverse/InfiniverseCompat.java
+++ b/src/main/java/de/melanx/skyblockbuilder/compat/infiniverse/InfiniverseCompat.java
@@ -1,5 +1,6 @@
 package de.melanx.skyblockbuilder.compat.infiniverse;
 
+import de.melanx.skyblockbuilder.SkyblockBuilder;
 import de.melanx.skyblockbuilder.config.common.SpawnConfig;
 import de.melanx.skyblockbuilder.config.common.WorldConfig;
 import de.melanx.skyblockbuilder.world.presets.SkyblockPreset;
@@ -82,6 +83,15 @@ public class InfiniverseCompat {
     }
 
     public static boolean useInfiniverse() {
-        return WorldConfig.dimensionPerTeam && ModList.get().isLoaded(MODID);
+        if (!WorldConfig.dimensionPerTeam) {
+            return false;
+        }
+
+        if (!ModList.get().isLoaded(MODID)) {
+            SkyblockBuilder.getLogger().warn("Infiniverse needs to be installed for dimensions per team! Falling back to shared dimensions.");
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/main/java/de/melanx/skyblockbuilder/compat/infiniverse/InfiniverseCompat.java
+++ b/src/main/java/de/melanx/skyblockbuilder/compat/infiniverse/InfiniverseCompat.java
@@ -1,0 +1,87 @@
+package de.melanx.skyblockbuilder.compat.infiniverse;
+
+import de.melanx.skyblockbuilder.config.common.SpawnConfig;
+import de.melanx.skyblockbuilder.config.common.WorldConfig;
+import de.melanx.skyblockbuilder.world.presets.SkyblockPreset;
+import net.commoble.infiniverse.api.InfiniverseAPI;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.MultiNoiseBiomeSourceParameterList;
+import net.minecraft.world.level.dimension.BuiltinDimensionTypes;
+import net.minecraft.world.level.dimension.DimensionType;
+import net.minecraft.world.level.dimension.LevelStem;
+import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
+import net.neoforged.fml.ModList;
+
+public class InfiniverseCompat {
+
+    public static final String MODID = "infiniverse";
+
+    public static void markDimensionForUnregistration(final MinecraftServer server, final ResourceKey<Level> levelToRemove) {
+        InfiniverseAPI.get().markDimensionForUnregistration(server, levelToRemove);
+    }
+
+    public static ServerLevel getOrCreateLevel(final MinecraftServer server, final ResourceKey<Level> levelKey, RegistryAccess registryAccess) {
+        return InfiniverseAPI.get().getOrCreateLevel(server, levelKey, () -> {
+            Registry<DimensionType> dimensionTypes = registryAccess.registryOrThrow(Registries.DIMENSION_TYPE);
+            Registry<MultiNoiseBiomeSourceParameterList> noises = registryAccess.registryOrThrow(Registries.MULTI_NOISE_BIOME_SOURCE_PARAMETER_LIST);
+            Registry<NoiseGeneratorSettings> noiseGeneratorSettings = registryAccess.registryOrThrow(Registries.NOISE_SETTINGS);
+            Registry<Biome> biomes = registryAccess.registryOrThrow(Registries.BIOME);
+
+            Holder<DimensionType> dimensionType = InfiniverseCompat.getDimensionType(registryAccess, dimensionTypes);
+
+            return new LevelStem(dimensionType, SkyblockPreset.configuredOverworldChunkGenerator(noises.asLookup(), noiseGeneratorSettings.asLookup(), biomes.asLookup()));
+        });
+    }
+
+    public static ServerLevel getOrCreateNetherLevel(final MinecraftServer server, final ResourceKey<Level> levelKey, RegistryAccess registryAccess) {
+        return InfiniverseAPI.get().getOrCreateLevel(server, levelKey, () -> {
+            Registry<DimensionType> dimensionTypes = registryAccess.registryOrThrow(Registries.DIMENSION_TYPE);
+            Registry<MultiNoiseBiomeSourceParameterList> noises = registryAccess.registryOrThrow(Registries.MULTI_NOISE_BIOME_SOURCE_PARAMETER_LIST);
+            Registry<NoiseGeneratorSettings> noiseGeneratorSettings = registryAccess.registryOrThrow(Registries.NOISE_SETTINGS);
+            Registry<Biome> biomes = registryAccess.registryOrThrow(Registries.BIOME);
+
+            return new LevelStem(
+                    dimensionTypes.getHolderOrThrow(BuiltinDimensionTypes.NETHER),
+                    SkyblockPreset.netherChunkGenerator(noises.asLookup(), noiseGeneratorSettings.asLookup(), biomes.asLookup())
+            );
+        });
+    }
+
+    private static Holder<DimensionType> getDimensionType(RegistryAccess registryAccess, Registry<DimensionType> dimensionTypes) {
+        ResourceKey<Level> spawnDimension = SpawnConfig.spawnDimension;
+        if (spawnDimension == Level.OVERWORLD) {
+            return dimensionTypes.getHolderOrThrow(BuiltinDimensionTypes.OVERWORLD);
+        }
+
+        if (spawnDimension == Level.NETHER) {
+            return dimensionTypes.getHolderOrThrow(BuiltinDimensionTypes.NETHER);
+        }
+
+        if (spawnDimension == Level.END) {
+            return dimensionTypes.getHolderOrThrow(BuiltinDimensionTypes.END);
+        }
+
+        Registry<Level> levels = registryAccess.registryOrThrow(Registries.DIMENSION);
+        Holder.Reference<Level> holderOrThrow = levels.getHolderOrThrow(SpawnConfig.spawnDimension);
+
+        if (holderOrThrow.isBound()) {
+            Level value = holderOrThrow.value();
+
+            return value.dimensionTypeRegistration();
+        }
+
+        return dimensionTypes.getHolderOrThrow(BuiltinDimensionTypes.OVERWORLD);
+    }
+
+    public static boolean useInfiniverse() {
+        return WorldConfig.dimensionPerTeam && ModList.get().isLoaded(MODID);
+    }
+}

--- a/src/main/java/de/melanx/skyblockbuilder/config/common/WorldConfig.java
+++ b/src/main/java/de/melanx/skyblockbuilder/config/common/WorldConfig.java
@@ -56,6 +56,9 @@ public class WorldConfig {
     @Config("If a player is leaving a team, it will teleported to overworld spawn instead of spawn island.")
     public static boolean leaveToOverworld = false;
 
-    @Config("Each team will get its own main dimension.")
+    @Config({"EXPERIMENTAL - needs proper testing!",
+            "Each team will get its own main dimension. Requires Infiniverse to be installed",
+            "- https://www.curseforge.com/minecraft/mc-mods/infiniverse",
+            "- https://modrinth.com/mod/infiniverse"})
     public static boolean dimensionPerTeam = false;
 }

--- a/src/main/java/de/melanx/skyblockbuilder/config/common/WorldConfig.java
+++ b/src/main/java/de/melanx/skyblockbuilder/config/common/WorldConfig.java
@@ -55,4 +55,7 @@ public class WorldConfig {
 
     @Config("If a player is leaving a team, it will teleported to overworld spawn instead of spawn island.")
     public static boolean leaveToOverworld = false;
+
+    @Config("Each team will get its own main dimension.")
+    public static boolean dimensionPerTeam = false;
 }

--- a/src/main/java/de/melanx/skyblockbuilder/data/SkyblockSavedData.java
+++ b/src/main/java/de/melanx/skyblockbuilder/data/SkyblockSavedData.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Sets;
 import de.melanx.skyblockbuilder.SkyblockBuilder;
 import de.melanx.skyblockbuilder.client.GameProfileCache;
 import de.melanx.skyblockbuilder.compat.CadmusCompat;
+import de.melanx.skyblockbuilder.compat.infiniverse.InfiniverseCompat;
 import de.melanx.skyblockbuilder.config.common.InventoryConfig;
 import de.melanx.skyblockbuilder.config.common.SpawnConfig;
 import de.melanx.skyblockbuilder.config.common.TemplatesConfig;
@@ -16,6 +17,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
@@ -128,15 +130,8 @@ public abstract class SkyblockSavedData extends SavedData {
     }
 
     public Pair<IslandPos, Team> create(String teamName, ConfiguredTemplate template) {
-        IslandPos islandPos;
-        Team team;
-        if (teamName.equalsIgnoreCase("spawn")) {
-            islandPos = this.nextSpawnPos(template);
-            team = new Team(this, islandPos, SPAWN_ID);
-        } else {
-            islandPos = this.nextIslandPos(template);
-            team = new Team(this, islandPos);
-        }
+        Team team = this.createTeamInternally(teamName, template);
+        IslandPos islandPos = team.getIsland();
 
         Set<TemplatesConfig.Spawn> positions = initialPossibleSpawns(islandPos.getCenter(), template);
 
@@ -147,6 +142,17 @@ public abstract class SkyblockSavedData extends SavedData {
 
         this.setDirty();
         return Pair.of(islandPos, team);
+    }
+
+    private Team createTeamInternally(String teamName, ConfiguredTemplate template) {
+        IslandPos islandPos;
+        boolean isSpawn = teamName.equalsIgnoreCase("spawn");
+
+        if (isSpawn) {
+            return new Team(this, this.nextSpawnPos(template), SPAWN_ID);
+        }
+
+        return new Team(this, this.nextSpawnPos(template));
     }
 
     @Nonnull
@@ -263,8 +269,18 @@ public abstract class SkyblockSavedData extends SavedData {
 
         ServerLevel level = this.getLevel();
         BlockPos center = team.getIsland().getCenter();
-        template.placeInWorld(level, team, TemplateUtil.STRUCTURE_PLACE_SETTINGS, RandomSource.create(), Block.UPDATE_CLIENTS);
-        SkyblockSavedData.surround(level, center, template);
+
+        ServerLevel teamLevel = this.getLevel();
+
+        if (InfiniverseCompat.useInfiniverse()) {
+            teamLevel = InfiniverseCompat.getOrCreateLevel(level.getServer(), team.getTeamLevelKey(), level.registryAccess());
+            if (!team.isSpawn()) {
+                InfiniverseCompat.getOrCreateNetherLevel(level.getServer(), team.getTeamNetherLevelKey(), level.registryAccess());
+            }
+        }
+
+        template.placeInWorld(teamLevel, team, TemplateUtil.STRUCTURE_PLACE_SETTINGS, RandomSource.create(), Block.UPDATE_CLIENTS);
+        SkyblockSavedData.surround(teamLevel, center, template);
 
         // team was already added to registry in create(); no need to add again
 
@@ -350,6 +366,13 @@ public abstract class SkyblockSavedData extends SavedData {
         this.registry.remove(teamId);
         this.onTeamDeleted(removedTeam);
 
+        if (InfiniverseCompat.useInfiniverse()) {
+            InfiniverseCompat.markDimensionForUnregistration(this.getLevel().getServer(), removedTeam.getTeamLevelKey());
+            if (!removedTeam.isSpawn()) {
+                InfiniverseCompat.markDimensionForUnregistration(this.getLevel().getServer(), removedTeam.getTeamNetherLevelKey());
+            }
+        }
+
         return true;
     }
 
@@ -383,7 +406,7 @@ public abstract class SkyblockSavedData extends SavedData {
     }
 
     public Collection<Team> getTeams() {
-        return this.registry.all();
+        return Collections.unmodifiableCollection(this.registry.all());
     }
 
     public void addInvite(Team team, Player invitor, Player player) {
@@ -619,6 +642,20 @@ public abstract class SkyblockSavedData extends SavedData {
             data.spiral = Spiral.fromArray(nbt.getIntArray(SPIRAL_STATE));
 
             return data;
+        }
+    }
+
+    public void restoreInfiniverseDimensions(MinecraftServer server) {
+        if (!InfiniverseCompat.useInfiniverse()) {
+            return;
+        }
+
+        RegistryAccess registryAccess = server.registryAccess();
+        for (Team team : this.registry.all()) {
+            InfiniverseCompat.getOrCreateLevel(server, team.getTeamLevelKey(), registryAccess);
+            if (!team.isSpawn()) {
+                InfiniverseCompat.getOrCreateNetherLevel(server, team.getTeamNetherLevelKey(), registryAccess);
+            }
         }
     }
 }

--- a/src/main/java/de/melanx/skyblockbuilder/data/Team.java
+++ b/src/main/java/de/melanx/skyblockbuilder/data/Team.java
@@ -1,5 +1,6 @@
 package de.melanx.skyblockbuilder.data;
 
+import de.melanx.skyblockbuilder.SkyblockBuilder;
 import de.melanx.skyblockbuilder.commands.invitation.InviteCommand;
 import de.melanx.skyblockbuilder.compat.minemention.MineMentionCompat;
 import de.melanx.skyblockbuilder.config.common.TemplatesConfig;
@@ -8,6 +9,7 @@ import de.melanx.skyblockbuilder.util.WorldUtil;
 import de.melanx.skyblockbuilder.world.IslandPos;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
@@ -15,10 +17,12 @@ import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.PlayerList;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
 import net.neoforged.fml.ModList;
 
 import javax.annotation.Nonnull;
@@ -57,6 +61,7 @@ public class Team {
     private final Set<TemplatesConfig.Spawn> defaultPossibleSpawns = new CopyOnWriteArraySet<>();
     private final Map<String, Set<PlacedSpread>> placedSpreads = new ConcurrentHashMap<>();
 
+    private ResourceKey<Level> teamLevelKey;
     private UUID teamId;
     private IslandPos island;
     private String name;
@@ -100,6 +105,21 @@ public class Team {
 
     public UUID getId() {
         return this.teamId;
+    }
+
+    public ResourceKey<Level> getTeamLevelKey() {
+        // need to do this in case id is null first
+        if (this.teamLevelKey == null) {
+            String path = this.isSpawn() ? "spawn" : this.teamId.toString().replace("-", "") + "_overworld";
+            this.teamLevelKey = ResourceKey.create(Registries.DIMENSION, SkyblockBuilder.getInstance().resource(path));
+        }
+
+        return this.teamLevelKey;
+    }
+
+    public ResourceKey<Level> getTeamNetherLevelKey() {
+        return ResourceKey.create(Registries.DIMENSION, SkyblockBuilder.getInstance().resource(
+                this.teamId.toString().replace("-", "") + "_nether"));
     }
 
     public void setName(String name) {

--- a/src/main/java/de/melanx/skyblockbuilder/mixin/BaseFireBlockMixin.java
+++ b/src/main/java/de/melanx/skyblockbuilder/mixin/BaseFireBlockMixin.java
@@ -1,0 +1,20 @@
+package de.melanx.skyblockbuilder.mixin;
+
+import de.melanx.skyblockbuilder.SkyblockBuilder;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.BaseFireBlock;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(BaseFireBlock.class)
+public class BaseFireBlockMixin {
+
+    @Inject(method = "inPortalDimension", at = @At(value = "RETURN"), cancellable = true)
+    private static void test(Level level, CallbackInfoReturnable<Boolean> cir) {
+        if (level.dimension().location().getNamespace().equals(SkyblockBuilder.getInstance().modid)) {
+            cir.setReturnValue(true);
+        }
+    }
+}

--- a/src/main/java/de/melanx/skyblockbuilder/network/SaveStructureHandler.java
+++ b/src/main/java/de/melanx/skyblockbuilder/network/SaveStructureHandler.java
@@ -38,6 +38,12 @@ public class SaveStructureHandler extends PacketHandler<SaveStructureHandler.Mes
             return;
         }
 
+        if (!player.hasPermissions(2)) {
+            player.sendSystemMessage(SkyComponents.NOT_ALLOWED_GENERIC);
+            SkyblockBuilder.getLogger().warn("Player {} tried to save a structure without permission", player.getGameProfile());
+            return;
+        }
+
         ServerLevel level = (ServerLevel) player.level();
         String name = ItemStructureSaver.saveSchematic(player, level, msg.stack, msg.settings);
         if (name == null) {

--- a/src/main/java/de/melanx/skyblockbuilder/util/WorldUtil.java
+++ b/src/main/java/de/melanx/skyblockbuilder/util/WorldUtil.java
@@ -28,6 +28,7 @@ import net.minecraft.world.level.biome.Climate;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 
 public class WorldUtil {
@@ -47,7 +48,10 @@ public class WorldUtil {
         }
 
         //noinspection ConstantConditions
-        ServerLevel level = WorldUtil.getConfiguredLevel(server);
+        ServerLevel level = server.getLevel(team.getTeamLevelKey());
+        if (level == null) {
+            level = Objects.requireNonNull(server.getLevel(server.overworld().dimension()));
+        }
 
         TemplatesConfig.Spawn spawn = WorldUtil.validPosition(level, team);
         player.teleportTo(level, spawn.pos().getX() + 0.5, spawn.pos().getY() + 0.2, spawn.pos().getZ() + 0.5, spawn.direction().getYRot(), 0);

--- a/src/main/java/de/melanx/skyblockbuilder/world/IslandPos.java
+++ b/src/main/java/de/melanx/skyblockbuilder/world/IslandPos.java
@@ -15,6 +15,7 @@ import net.minecraft.world.level.Level;
  */
 public final class IslandPos {
 
+    public static final IslandPos CENTERED = new IslandPos(0, 0, BlockPos.ZERO);
     public static final String ISLAND_X = "island_x";
     public static final String ISLAND_Z = "island_z";
     public static final String CENTER_POS = "center_pos";

--- a/src/main/java/de/melanx/skyblockbuilder/world/presets/SkyblockPreset.java
+++ b/src/main/java/de/melanx/skyblockbuilder/world/presets/SkyblockPreset.java
@@ -115,7 +115,7 @@ public class SkyblockPreset extends WorldPreset {
         return new SkyblockNoiseBasedChunkGenerator(biomeSource, settings, Level.OVERWORLD, SkyblockPreset.getLayers(Level.OVERWORLD));
     }
 
-    private static ChunkGenerator netherChunkGenerator(
+    public static ChunkGenerator netherChunkGenerator(
             HolderGetter<MultiNoiseBiomeSourceParameterList> noises,
             HolderGetter<NoiseGeneratorSettings> noiseGeneratorSettings,
             HolderLookup<Biome> biomes

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -8,9 +8,14 @@ public net.minecraft.client.gui.screens.worldselection.CreateWorldScreen openDat
 public net.minecraft.client.gui.screens.worldselection.WorldGenSettingsComponent preset
 public net.minecraft.client.gui.screens.worldselection.WorldGenSettingsComponent updateSettings(Lnet/minecraft/client/gui/screens/worldselection/WorldCreationContext;)V
 
+public-f net.minecraft.core.RegistryAccess$ImmutableRegistryAccess registries
+public-f net.minecraft.core.LayeredRegistryAccess values
+
 public net.minecraft.network.Connection channel
 
 public net.minecraft.server.MinecraftServer storageSource
+public net.minecraft.server.MinecraftServer progressListenerFactory
+public net.minecraft.server.MinecraftServer executor
 public net.minecraft.server.level.ServerLevel findLightningRod(Lnet/minecraft/core/BlockPos;)Ljava/util/Optional;
 public net.minecraft.server.players.GameProfileCache$GameProfileInfo
 
@@ -45,3 +50,6 @@ protected net.minecraft.world.level.chunk.ChunkGenerator featuresPerStep
 protected net.minecraft.world.level.chunk.ChunkGenerator generationSettingsGetter
 protected net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator settings
 protected net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator createNoiseChunk(Lnet/minecraft/world/level/chunk/ChunkAccess;Lnet/minecraft/world/level/StructureManager;Lnet/minecraft/world/level/levelgen/blending/Blender;Lnet/minecraft/world/level/levelgen/RandomState;)Lnet/minecraft/world/level/levelgen/NoiseChunk;
+
+public net.minecraft.world.level.border.WorldBorder listeners
+public net.minecraft.world.level.border.BorderChangeListener$DelegateBorderChangeListener worldBorder

--- a/src/main/resources/assets/skyblockbuilder/lang/de_de.json
+++ b/src/main/resources/assets/skyblockbuilder/lang/de_de.json
@@ -171,6 +171,7 @@
   "task.skyblockbuilder.spread_location.title.plural": "Finde %s Ausbreitungen",
   "heracles.skyblockbuilder.reset_quest_progress": "Questfortschritt wurde zurückgesetzt.",
   "cadmus.skyblockbuilder.claim_spawn": "Spawnchunks erfolgreich geclaimt.",
+  "infiniverse.skyblockbuilder.not_loaded": "Infiniverse muss für Dimensionen pro Team installiert sein! Es wird stattdessen auf geteilte Dimensionen zurückgegriffen.",
 
   "skyblockbuilder.screen.dump.title": "Skyblock Builder Abbild",
   "skyblockbuilder.screen.dump.text.configs": "Konfigurationen",

--- a/src/main/resources/assets/skyblockbuilder/lang/en_us.json
+++ b/src/main/resources/assets/skyblockbuilder/lang/en_us.json
@@ -171,6 +171,7 @@
   "task.skyblockbuilder.spread_location.title.plural": "Find %s Spreads",
   "heracles.skyblockbuilder.reset_quest_progress": "Reset quest progression.",
   "cadmus.skyblockbuilder.claim_spawn": "Successfully claimed spawn chunks.",
+  "infiniverse.skyblockbuilder.not_loaded": "Infiniverse needs to be installed for dimensions per team! Falling back to shared dimensions.",
 
   "skyblockbuilder.screen.dump.title": "Skyblock Builder Dump",
   "skyblockbuilder.screen.dump.text.configs": "Configs",

--- a/src/main/resources/skyblockbuilder.mixins.json
+++ b/src/main/resources/skyblockbuilder.mixins.json
@@ -6,5 +6,5 @@
   "minVersion": "0.8",
   "client": [ "CreateWorldScreenMixin", "LivingEntityRendererMixin", "WorldOpenFlowsMixin" ],
   "server": [ ],
-  "mixins": [ "NetherPortalBlockMixin", "PackRepositoryMixin", "ServerMainMixin" ]
+  "mixins": [ "BaseFireBlockMixin", "NetherPortalBlockMixin", "PackRepositoryMixin", "ServerMainMixin" ]
 }


### PR DESCRIPTION
This pull request adds the per team dimensions generation feature as requested in https://github.com/ChaoticTrials/SkyblockBuilder/issues/203.

For testing the per team dimensions, you need to enable `dimensionPerTeam` in `world.json5` config file. Additionally, you need to have Infiniverse loaded.
CurseForge: https://www.curseforge.com/minecraft/mc-mods/infiniverse
Modrinth: https://modrinth.com/mod/infiniverse

Only vanilla dimensions are handled with that. Additional modded dimensions or dimensions added by data packs aren't supported nor will ever be. Teleporting to other dimensions that may require the overworld or nether as base dimension should work and those bugs would get fixed.

## How to test
Look here for latest file: https://github.com/ChaoticTrials/SkyblockBuilder/actions/workflows/dev_publish.yml?query=branch%3Afeature%2Fper-team-dimensions